### PR TITLE
test: check ParkingFinder header

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,12 @@
 import { render, screen } from '@testing-library/react';
+
+jest.mock('./components/RichmondMap', () => () => null);
+jest.mock('./components/ParkingChart', () => () => null);
+
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders header text', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText(/ParkingFinder/i);
+  expect(headerElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- ensure App renders ParkingFinder header
- mock incompatible components for tests

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a4bd02a7448327b11e590bcb83f295