### PR TITLE
Fix cancellation logic and stabilize tests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,12 +38,12 @@ function App() {
   const handleCancelReservation = (locationName) => {
     setParkingData(prevData =>
       prevData.map(spot =>
-        spot.location.toLowerCase() === locationName.toLowerCase() && spot.availableSpots > 0
+        spot.location.toLowerCase() === locationName.toLowerCase()
           ? { ...spot, availableSpots: spot.availableSpots + 1 }
           : spot
       )
     );
-  };  
+  };
 
   return (
     <div className="App">

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import React from 'react';
 
-test('renders learn react link', () => {
+// Mock components that rely on browser-specific APIs
+jest.mock('./components/RichmondMap', () => () => <div>Mocked RichmondMap</div>);
+jest.mock('./components/ParkingChart', () => () => <div>Mocked ParkingChart</div>);
+
+test('renders ParkingFinder header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText(/ParkingFinder/i);
+  expect(headerElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- Allow canceled reservations to restore parking spot availability
- Mock map and chart components in tests and validate app header

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a4ba220ee083278e2a4b380da43ca8