### PR TITLE
Restore spot on cancellation and add regression test

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,15 +6,17 @@ import RichmondMap from './components/RichmondMap';
 import ReservationDetails from './components/ReservationDetails';
 import ParkingChart from './components/ParkingChart';
 
-function App() {
+function App({ initialParkingData }) {
   const [reservationDetails, setReservationDetails] = useState('');
-  
-  const [parkingData, setParkingData] = useState([
-    { location: 'Shockoe Bottom', availableSpots: 7 },
-    { location: 'The Fan', availableSpots: 2 },
-    { location: 'Scotts Addition', availableSpots: 10 },
-    { location: 'Carytown', availableSpots: 22}
-  ]);
+
+  const [parkingData, setParkingData] = useState(
+    initialParkingData || [
+      { location: 'Shockoe Bottom', availableSpots: 7 },
+      { location: 'The Fan', availableSpots: 2 },
+      { location: 'Scotts Addition', availableSpots: 10 },
+      { location: 'Carytown', availableSpots: 22 }
+    ]
+  );
 
   const handleReserveSpot = (locationName) => {
     setParkingData(prevData =>
@@ -38,12 +40,12 @@ function App() {
   const handleCancelReservation = (locationName) => {
     setParkingData(prevData =>
       prevData.map(spot =>
-        spot.location.toLowerCase() === locationName.toLowerCase() && spot.availableSpots > 0
-          ? { ...spot, availableSpots: spot.availableSpots + 1 }
+        spot.location.toLowerCase() === locationName.toLowerCase()
+          ? { ...spot, availableSpots: Math.max(spot.availableSpots + 1, 0) }
           : spot
       )
     );
-  };  
+  };
 
   return (
     <div className="App">

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,25 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+jest.mock('./components/RichmondMap', () => () => <div />);
+jest.mock('./components/ParkingChart', () => () => <div />);
+
+test('cancelling a reservation restores the previously consumed spot', async () => {
+  render(
+    <App initialParkingData={[{ location: 'Test Location', availableSpots: 1 }]} />
+  );
+
+  const input = screen.getByPlaceholderText(/enter location/i);
+  const findButton = screen.getByRole('button', { name: /find parking/i });
+  const reserveButton = screen.getByRole('button', { name: /reserve spot/i });
+  const cancelButton = screen.getByRole('button', { name: /cancel reservation/i });
+
+  await userEvent.type(input, 'Test Location');
+  await userEvent.click(findButton);
+  await userEvent.click(reserveButton);
+  await userEvent.click(cancelButton);
+  await userEvent.click(findButton);
+
+  expect(screen.getByText(/spot found at test location/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- Remove availableSpots guard in `handleCancelReservation` and clamp incremented value
- Allow `App` to receive custom initial parking data for easier testing
- Add regression test ensuring cancelled reservations free a spot

## Testing
- `CI=true npm test -- --runTestsByPath src/App.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a4bcff0c0c83279dfc0cd4ed423e06